### PR TITLE
fix(cfg): Improve string handling of bools

### DIFF
--- a/internal/config/unmarshal.go
+++ b/internal/config/unmarshal.go
@@ -151,13 +151,13 @@ func (bit *Bool) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	resolved = strings.Replace(resolved, `"`, "", -1)
+	resolved = strings.Trim(resolved, `"`)
 
 	return json.Unmarshal([]byte(resolved), (*alias)(bit))
 }
 
 func (bit *Bool) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	type alias Bool
+	type boolAlias Bool
 
 	var data string
 
@@ -171,9 +171,9 @@ func (bit *Bool) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 
-	resolved = strings.Replace(resolved, `"`, "", -1)
+	resolved = strings.Trim(resolved, `"`)
 
-	return yaml.UnmarshalStrict([]byte(resolved), (*alias)(bit))
+	return yaml.UnmarshalStrict([]byte(resolved), (*boolAlias)(bit))
 }
 
 type String string
@@ -194,7 +194,7 @@ func (str *String) UnmarshalJSON(data []byte) error {
 }
 
 func (str *String) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	type alias String
+	type stringAlias String
 
 	var data string
 
@@ -208,5 +208,5 @@ func (str *String) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 
-	return yaml.UnmarshalStrict([]byte(resolved), (*alias)(str))
+	return yaml.UnmarshalStrict([]byte(resolved), (*stringAlias)(str))
 }

--- a/internal/config/unmarshal_test.go
+++ b/internal/config/unmarshal_test.go
@@ -56,19 +56,16 @@ func Test_Resolve(t *testing.T) {
 		{
 			description:   "environment variable not set",
 			input:         "{{env:UNSET_1}}",
-			expected:      "",
 			expectedError: "not set",
 		},
 		{
 			description:   "malformed placeholder",
 			input:         "{{env_UNSET_1}}",
-			expected:      "",
 			expectedError: "malformed placeholder",
 		},
 		{
 			description:   "unsupported placeholder",
 			input:         "{{gcp:SET_1}}",
-			expected:      "",
 			expectedError: "unsupported placeholder",
 		},
 	}
@@ -79,8 +76,8 @@ func Test_Resolve(t *testing.T) {
 			require := require.New(t)
 
 			actual, err := config.Resolve(testCase.input)
-			assert.Equal(testCase.expected, actual)
 			if testCase.expectedError == "" {
+				assert.Equal(testCase.expected, actual)
 				assert.NoError(err)
 			} else {
 				require.Error(err)
@@ -142,10 +139,21 @@ func Test_Unmarshal(t *testing.T) {
 			},
 		},
 		{
+			description:   "invalid JSON bool",
+			input:         `{"Bool": "tr\"ue", "String": "hello"}`,
+			extension:     ".json",
+			expectedError: "invalid character",
+		},
+		{
+			description:   "invalid YAML bool",
+			input:         "bool: y\"e\"s\nstring: hello",
+			extension:     ".yaml",
+			expectedError: "cannot unmarshal",
+		},
+		{
 			description:   "unsupported file extension",
 			input:         "",
 			extension:     ".xml",
-			expected:      nil,
 			expectedError: "unsupported file extension",
 		},
 	}
@@ -158,8 +166,8 @@ func Test_Unmarshal(t *testing.T) {
 			var data *Data
 
 			err := config.Unmarshal(testCase.extension, []byte(testCase.input), &data)
-			assert.Equal(testCase.expected, data)
 			if testCase.expectedError == "" {
+				assert.Equal(testCase.expected, data)
 				assert.NoError(err)
 			} else {
 				require.Error(err)


### PR DESCRIPTION
Quote removal on bool fields is now limited to prefixes and suffixes. This blocks bad input  like:

```yaml
bool: y"e"s
```