### PR TITLE
feat(cfg): Support aws:ssm:parameter placeholders

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -36,7 +36,7 @@ stacks:
 
     capabilities: []
     parameters: []
-    terminationProtection: '{{env:TERMINATION_PROTECTION}}'
+    terminationProtection: '{{aws:ssm:parameter:termination-protection}}'
 
     policyFile: ./policy.json
     templateFile: ./template.yaml

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -69,11 +69,6 @@ func New() (_ *App, err error) {
 		return nil, fmt.Errorf("command '%s' not recognised", commandName)
 	}
 
-	cfg, err := config.FromPath(*cfgPath)
-	if err != nil {
-		return nil, err
-	}
-
 	httpClient := &http.Client{Timeout: 10 * time.Second}
 
 	awsConfig := aws.NewConfig().WithHTTPClient(httpClient)
@@ -86,6 +81,13 @@ func New() (_ *App, err error) {
 	cloudFormation := cloudformation.New(provider)
 
 	client := stratus.NewClient(cloudFormation)
+
+	config.Init(provider)
+
+	cfg, err := config.FromPath(*cfgPath)
+	if err != nil {
+		return nil, err
+	}
 
 	app := &App{
 		cfg:     cfg,

--- a/internal/command/mock_test.go
+++ b/internal/command/mock_test.go
@@ -20,8 +20,8 @@ var (
 	mockStackPolicyBody = mustMarshal(mockStackPolicy)
 )
 
-func mustMarshal(value interface{}) []byte {
-	data, err := json.Marshal(value)
+func mustMarshal(model interface{}) []byte {
+	data, err := json.Marshal(model)
 	if err != nil {
 		panic(fmt.Errorf("mustMarshal: %+v", err))
 	}

--- a/internal/config/unmarshal.go
+++ b/internal/config/unmarshal.go
@@ -144,7 +144,7 @@ func (bit *Bool) Bool() bool {
 }
 
 func (bit *Bool) UnmarshalJSON(data []byte) error {
-	type alias Bool
+	type boolAlias Bool
 
 	resolved, err := Resolve(string(data))
 	if err != nil {
@@ -153,7 +153,7 @@ func (bit *Bool) UnmarshalJSON(data []byte) error {
 
 	resolved = strings.Trim(resolved, `"`)
 
-	return json.Unmarshal([]byte(resolved), (*alias)(bit))
+	return json.Unmarshal([]byte(resolved), (*boolAlias)(bit))
 }
 
 func (bit *Bool) UnmarshalYAML(unmarshal func(interface{}) error) error {
@@ -183,14 +183,14 @@ func (str *String) String() string {
 }
 
 func (str *String) UnmarshalJSON(data []byte) error {
-	type alias String
+	type stringAlias String
 
 	resolved, err := Resolve(string(data))
 	if err != nil {
 		return err
 	}
 
-	return json.Unmarshal([]byte(resolved), (*alias)(str))
+	return json.Unmarshal([]byte(resolved), (*stringAlias)(str))
 }
 
 func (str *String) UnmarshalYAML(unmarshal func(interface{}) error) error {

--- a/internal/config/unmarshal.go
+++ b/internal/config/unmarshal.go
@@ -32,13 +32,13 @@ func envMapper(placeholder string) (string, error) {
 	return resolved, nil
 }
 
-func Unmarshal(extension string, data []byte, dest interface{}) error {
+func Unmarshal(extension string, data []byte, model interface{}) error {
 	unmarshal, ok := extensionToUnmarshal[extension]
 	if !ok {
 		return fmt.Errorf("unsupported file extension '%s'", extension)
 	}
 
-	return unmarshal(data, dest)
+	return unmarshal(data, model)
 }
 
 type ResolveStack []*strings.Builder

--- a/internal/config/unmarshal_test.go
+++ b/internal/config/unmarshal_test.go
@@ -10,6 +10,10 @@ import (
 	"github.com/72636c/stratus/internal/config"
 )
 
+func init() {
+	config.Init(nil)
+}
+
 func Test_Resolve(t *testing.T) {
 	os.Setenv("SET_1", "serious")
 	os.Setenv("SET_2", "prod")


### PR DESCRIPTION
This is intended for future config fields, such as an S3 bucket name for uploading artefacts. CloudFormation templates can already define parameters that reference Parameter Store via the [relevant types](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html#aws-ssm-parameter-types).