### PR TITLE
fix(cfg): Correct stack checksums

### DIFF
--- a/internal/config/checksum.go
+++ b/internal/config/checksum.go
@@ -1,0 +1,18 @@
+package config
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+)
+
+func CalculateChecksum(model interface{}) (string, error) {
+	data, err := json.Marshal(model)
+	if err != nil {
+		return "", err
+	}
+
+	checksum := fmt.Sprintf("%x", sha256.Sum256(data))
+
+	return checksum, nil
+}

--- a/internal/config/checksum_test.go
+++ b/internal/config/checksum_test.go
@@ -1,0 +1,60 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/72636c/stratus/internal/config"
+)
+
+func Test_CalculateChecksum(t *testing.T) {
+	testCases := []struct {
+		description string
+		input       func() interface{}
+		expected    string
+	}{
+		{
+			description: "map",
+			input: func() interface{} {
+				return map[string]interface{}{
+					"c": -1,
+					"a": "hello",
+					"b": true,
+				}
+			},
+			expected: "a43ce2809f97260129f7bfd1352033ced8379cb4bff7a87a606bc7b136ba496d",
+		},
+		{
+			description: "struct",
+			input: func() interface{} {
+				return struct {
+					C int    `json:"c"`
+					A string `json:"a"`
+					B bool   `json:"b"`
+				}{
+					C: -1,
+					A: "hello",
+					B: true,
+				}
+			},
+			expected: "481dadb27dfdb867222436adf2b1ae52715838e21fe1cae7ae9ebfbd16286690",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			assert := assert.New(t)
+
+			for index := 0; index < 100; index++ {
+				actual, err := config.CalculateChecksum(testCase.input())
+				passed1 := assert.Equal(testCase.expected, actual)
+				passed2 := assert.NoError(err)
+
+				if !(passed1 && passed2) {
+					break
+				}
+			}
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,8 +1,6 @@
 package config
 
 import (
-	"crypto/sha256"
-	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"strings"
@@ -22,8 +20,6 @@ func FromPath(path string) (*Config, error) {
 		return nil, err
 	}
 
-	checksum := fmt.Sprintf("%x", sha256.Sum256(data))
-
 	var raw *RawConfig
 
 	err = Unmarshal(extension, data, &raw)
@@ -33,7 +29,7 @@ func FromPath(path string) (*Config, error) {
 
 	// TODO: validate config
 
-	return fromRawConfig(raw, checksum, path)
+	return fromRawConfig(raw, path)
 }
 
 type Stack struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,7 +43,7 @@ type Stack struct {
 	Policy   interface{}
 	Template []byte
 
-	Checksum string
+	Checksum string `json:"-"`
 }
 
 func (stack *Stack) String() string {

--- a/internal/config/mapping.go
+++ b/internal/config/mapping.go
@@ -1,16 +1,25 @@
 package config
 
 import (
+	"crypto/sha256"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
 )
 
 func fromRawConfig(
 	raw *RawConfig,
-	checksum string,
 	relativePath string,
 ) (*Config, error) {
+	data, err := json.Marshal(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	// FIXME: this does not account for external files
+	checksum := fmt.Sprintf("%x", sha256.Sum256(data))
+
 	stacks, err := fromRawStacks(raw.Stacks, checksum, relativePath)
 	if err != nil {
 		return nil, err

--- a/internal/config/mapping.go
+++ b/internal/config/mapping.go
@@ -1,26 +1,13 @@
 package config
 
 import (
-	"crypto/sha256"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"path/filepath"
 )
 
-func fromRawConfig(
-	raw *RawConfig,
-	relativePath string,
-) (*Config, error) {
-	data, err := json.Marshal(raw)
-	if err != nil {
-		return nil, err
-	}
-
-	// FIXME: this does not account for external files
-	checksum := fmt.Sprintf("%x", sha256.Sum256(data))
-
-	stacks, err := fromRawStacks(raw.Stacks, checksum, relativePath)
+func fromRawConfig(raw *RawConfig, path string) (*Config, error) {
+	stacks, err := fromRawStacks(raw.Stacks, path)
 	if err != nil {
 		return nil, err
 	}
@@ -32,17 +19,13 @@ func fromRawConfig(
 	return config, nil
 }
 
-func fromRawStacks(
-	raw []*RawStack,
-	checksum string,
-	relativePath string,
-) ([]*Stack, error) {
+func fromRawStacks(raw []*RawStack, path string) ([]*Stack, error) {
 	slice := make([]*Stack, len(raw))
 
 	for index, stack := range raw {
 		var err error
 
-		slice[index], err = fromRawStack(stack, checksum, relativePath)
+		slice[index], err = fromRawStack(stack, path)
 		if err != nil {
 			return nil, err
 		}
@@ -51,13 +34,9 @@ func fromRawStacks(
 	return slice, nil
 }
 
-func fromRawStack(
-	raw *RawStack,
-	checksum string,
-	relativePath string,
-) (*Stack, error) {
+func fromRawStack(raw *RawStack, path string) (*Stack, error) {
 	policyPath := filepath.Join(
-		filepath.Dir(relativePath),
+		filepath.Dir(path),
 		raw.PolicyFile.String(),
 	)
 
@@ -74,7 +53,7 @@ func fromRawStack(
 	}
 
 	templatePath := filepath.Join(
-		filepath.Dir(relativePath),
+		filepath.Dir(path),
 		raw.TemplateFile.String(),
 	)
 
@@ -93,9 +72,14 @@ func fromRawStack(
 
 		Policy:   policy,
 		Template: template,
-
-		Checksum: checksum,
 	}
+
+	checksum, err := CalculateChecksum(stack)
+	if err != nil {
+		return nil, err
+	}
+
+	stack.Checksum = checksum
 
 	return stack, nil
 }


### PR DESCRIPTION
Checksums are now

- Calculated separately on each stack
- Inclusive of external policy and template file contents
- Inclusive of evaluated placeholder values