### PR TITLE
feat(cfg): Upload artefacts to S3

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -32,7 +32,7 @@ A YAML config file looks like:
 
 ```yaml
 defaults:
-  uploadArtefacts: s3://{{aws:ssm:parameter:artefact-bucket}}
+  uploadArtefacts: '{{aws:ssm:parameter:artefact-bucket}}'
 
 stacks:
   - name: stratus-sample-{{env:ENVIRONMENT}}

--- a/README.adoc
+++ b/README.adoc
@@ -31,12 +31,15 @@ link:/samples[`/samples`]
 A YAML config file looks like:
 
 ```yaml
+defaults:
+  uploadArtefacts: s3://{{aws:ssm:parameter:artefact-bucket}}
+
 stacks:
   - name: stratus-sample-{{env:ENVIRONMENT}}
 
     capabilities: []
     parameters: []
-    terminationProtection: '{{aws:ssm:parameter:termination-protection}}'
+    terminationProtection: true
 
     policyFile: ./policy.json
     templateFile: ./template.yaml

--- a/README.adoc
+++ b/README.adoc
@@ -32,7 +32,7 @@ A YAML config file looks like:
 
 ```yaml
 defaults:
-  uploadArtefacts: '{{aws:ssm:parameter:artefact-bucket}}'
+  artefactBucket: '{{aws:ssm:parameter:artefact-bucket}}'
 
 stacks:
   - name: stratus-sample-{{env:ENVIRONMENT}}

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/aws/aws-sdk-go/service/s3"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/72636c/stratus/internal/config"
@@ -78,9 +79,10 @@ func New() (_ *App, err error) {
 		return nil, err
 	}
 
-	cloudFormation := cloudformation.New(provider)
+	cfnClient := cloudformation.New(provider)
+	s3Client := s3.New(provider)
 
-	client := stratus.NewClient(cloudFormation)
+	client := stratus.NewClient(cfnClient, s3Client)
 
 	config.Init(provider)
 

--- a/internal/command/delete_happy_test.go
+++ b/internal/command/delete_happy_test.go
@@ -38,7 +38,7 @@ func Test_Delete_Happy(t *testing.T) {
 		).
 		Return(nil)
 
-	client := stratus.NewClient(cfn)
+	client := stratus.NewClient(cfn, nil)
 
 	err := command.Delete(context.Background(), client, stack)
 	assert.NoError(err)

--- a/internal/command/mock_test.go
+++ b/internal/command/mock_test.go
@@ -1,15 +1,18 @@
 package command_test
 
 import (
-	"encoding/json"
 	"fmt"
 )
 
 const (
 	mockChecksum = "1000000000200000000030000000004000000000500000000060000000007000"
 
+	mockArtefactBucket   = "test-bucket-name"
+	mockStackPolicyKey   = "test-policy-key"
+	mockStackTemplateKey = "test-template-key"
+
 	mockStackName     = "test-stack-name"
-	mockStackPolicy   = "test-stack-policy"
+	mockStackPolicy   = `"test-stack-policy"`
 	mockStackTemplate = "test-stack-template"
 )
 
@@ -17,14 +20,6 @@ var (
 	mockChangeSetCreateName = fmt.Sprintf("stratus-create-%s", mockChecksum)
 	mockChangeSetUpdateName = fmt.Sprintf("stratus-update-%s", mockChecksum)
 
-	mockStackPolicyBody = mustMarshal(mockStackPolicy)
+	mockStackPolicyURL   = fmt.Sprintf("https://s3.amazonaws.com/%s/%s", mockArtefactBucket, mockStackPolicyKey)
+	mockStackTemplateURL = fmt.Sprintf("https://s3.amazonaws.com/%s/%s", mockArtefactBucket, mockStackTemplateKey)
 )
-
-func mustMarshal(model interface{}) []byte {
-	data, err := json.Marshal(model)
-	if err != nil {
-		panic(fmt.Errorf("mustMarshal: %+v", err))
-	}
-
-	return data
-}

--- a/internal/command/preview.go
+++ b/internal/command/preview.go
@@ -34,6 +34,15 @@ func Preview(
 
 		output <- validateOutput
 
+		if stack.ShouldUpload() {
+			output <- "Upload artefacts"
+
+			err = client.UploadArtefacts(ctx, stack)
+			if err != nil {
+				return nil, err
+			}
+		}
+
 		output <- "Create change set"
 
 		describeOutput, err = client.CreateChangeSet(ctx, stack)

--- a/internal/command/preview_happy_test.go
+++ b/internal/command/preview_happy_test.go
@@ -1,12 +1,16 @@
 package command_test
 
 import (
+	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/mock"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/72636c/stratus/internal/command"
@@ -20,6 +24,8 @@ func Test_Preview_Happy_ExistingChangeSet(t *testing.T) {
 
 	stack := &config.Stack{
 		Name: mockStackName,
+
+		Policy: []byte(mockStackPolicy),
 
 		Checksum: mockChecksum,
 	}
@@ -76,7 +82,7 @@ func Test_Preview_Happy_ExistingChangeSet(t *testing.T) {
 		).
 		Return(nil, nil)
 
-	client := stratus.NewClient(cfn)
+	client := stratus.NewClient(cfn, nil)
 
 	_, err := command.Preview(context.Background(), client, stack)
 	assert.NoError(err)
@@ -88,6 +94,7 @@ func Test_Preview_Happy_NewChangeSet_Create(t *testing.T) {
 	stack := &config.Stack{
 		Name: mockStackName,
 
+		Policy:   []byte(mockStackPolicy),
 		Template: []byte(mockStackTemplate),
 
 		Checksum: mockChecksum,
@@ -178,7 +185,7 @@ func Test_Preview_Happy_NewChangeSet_Create(t *testing.T) {
 		).
 		Return(nil, nil)
 
-	client := stratus.NewClient(cfn)
+	client := stratus.NewClient(cfn, nil)
 
 	_, err := command.Preview(context.Background(), client, stack)
 	assert.NoError(err)
@@ -190,6 +197,7 @@ func Test_Preview_Happy_NewChangeSet_Update(t *testing.T) {
 	stack := &config.Stack{
 		Name: mockStackName,
 
+		Policy:   []byte(mockStackPolicy),
 		Template: []byte(mockStackTemplate),
 
 		Checksum: mockChecksum,
@@ -266,18 +274,18 @@ func Test_Preview_Happy_NewChangeSet_Update(t *testing.T) {
 		).
 		Return(nil, nil)
 
-	client := stratus.NewClient(cfn)
+	client := stratus.NewClient(cfn, nil)
 
 	_, err := command.Preview(context.Background(), client, stack)
 	assert.NoError(err)
 }
-
 func Test_Preview_Happy_NoopChangeSet(t *testing.T) {
 	assert := assert.New(t)
 
 	stack := &config.Stack{
 		Name: mockStackName,
 
+		Policy:   []byte(mockStackPolicy),
 		Template: []byte(mockStackTemplate),
 
 		Checksum: mockChecksum,
@@ -360,7 +368,136 @@ func Test_Preview_Happy_NoopChangeSet(t *testing.T) {
 		).
 		Return(nil, nil)
 
-	client := stratus.NewClient(cfn)
+	client := stratus.NewClient(cfn, nil)
+
+	_, err := command.Preview(context.Background(), client, stack)
+	assert.NoError(err)
+}
+
+func Test_Preview_Happy_NoopChangeSet_UploadArtefacts(t *testing.T) {
+	assert := assert.New(t)
+
+	stack := &config.Stack{
+		Name: mockStackName,
+
+		Policy:   []byte(mockStackPolicy),
+		Template: []byte(mockStackTemplate),
+
+		ArtefactBucket: mockArtefactBucket,
+		PolicyKey:      mockStackPolicyKey,
+		TemplateKey:    mockStackTemplateKey,
+
+		Checksum: mockChecksum,
+	}
+
+	cfn := stratus.NewCloudFormationMock()
+	defer cfn.AssertExpectations(t)
+	cfn.
+		On(
+			"ListChangeSetsWithContext",
+			&cloudformation.ListChangeSetsInput{
+				StackName: aws.String(stack.Name),
+			},
+		).
+		Return(nil, awserr.New("ValidationError", "does not exist", nil)).
+		On(
+			"ValidateTemplateWithContext",
+			&cloudformation.ValidateTemplateInput{
+				TemplateBody: aws.String(string(stack.Template)),
+			},
+		).
+		Return(nil, nil).
+		On(
+			"CreateChangeSetWithContext",
+			&cloudformation.CreateChangeSetInput{
+				Capabilities:        make([]*string, 0),
+				ChangeSetName:       aws.String(mockChangeSetUpdateName),
+				ChangeSetType:       aws.String(cloudformation.ChangeSetTypeUpdate),
+				StackName:           aws.String(stack.Name),
+				Parameters:          make([]*cloudformation.Parameter, 0),
+				Tags:                make([]*cloudformation.Tag, 0),
+				TemplateURL:         aws.String(mockStackTemplateURL),
+				UsePreviousTemplate: aws.Bool(false),
+			},
+		).
+		Return(nil, nil).
+		On(
+			"WaitUntilChangeSetCreateCompleteWithContext",
+			&cloudformation.DescribeChangeSetInput{
+				ChangeSetName: aws.String(mockChangeSetUpdateName),
+				StackName:     aws.String(stack.Name),
+			},
+		).
+		Return(awserr.New(request.WaiterResourceNotReadyErrorCode, "", nil)).
+		On(
+			"DescribeChangeSetWithContext",
+			&cloudformation.DescribeChangeSetInput{
+				ChangeSetName: aws.String(mockChangeSetUpdateName),
+				StackName:     aws.String(stack.Name),
+			},
+		).
+		Return(
+			&cloudformation.DescribeChangeSetOutput{
+				Status:       aws.String(cloudformation.ChangeSetStatusFailed),
+				StatusReason: aws.String("The submitted information didn't contain changes. Submit different information to create a change set."),
+			},
+			nil,
+		).
+		On(
+			"DescribeStacksWithContext",
+			&cloudformation.DescribeStacksInput{
+				StackName: aws.String(stack.Name),
+			},
+		).
+		Return(
+			&cloudformation.DescribeStacksOutput{
+				Stacks: []*cloudformation.Stack{
+					&cloudformation.Stack{
+						EnableTerminationProtection: aws.Bool(false),
+					},
+				},
+			},
+			nil,
+		).
+		On(
+			"GetStackPolicyWithContext",
+			&cloudformation.GetStackPolicyInput{
+				StackName: aws.String(stack.Name),
+			},
+		).
+		Return(nil, nil)
+
+	s3Client := stratus.NewS3Mock()
+	defer s3Client.AssertExpectations(t)
+	s3Client.
+		On(
+			"PutObjectWithContext",
+			mock.MatchedBy(
+				s3Client.PutObjectWithContextMatcher(
+					&s3.PutObjectInput{
+						Body:   strings.NewReader(mockStackPolicy),
+						Bucket: aws.String(mockArtefactBucket),
+						Key:    aws.String(mockStackPolicyKey),
+					},
+				),
+			),
+		).
+		Return(nil, nil).
+		On(
+			"PutObjectWithContext",
+			mock.MatchedBy(
+				s3Client.PutObjectWithContextMatcher(
+					&s3.PutObjectInput{
+						Body:   strings.NewReader(mockStackTemplate),
+						Bucket: aws.String(mockArtefactBucket),
+						Key:    aws.String(mockStackTemplateKey),
+					},
+				),
+			),
+		).
+		Return(nil, nil)
+
+	client := stratus.NewClient(cfn, s3Client)
 
 	_, err := command.Preview(context.Background(), client, stack)
 	assert.NoError(err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,11 +40,18 @@ type Stack struct {
 	Tags                  StackTags
 	TerminationProtection bool
 
-	Policy          interface{}
-	Template        []byte
-	UploadArtefacts string
+	Policy   []byte
+	Template []byte
+
+	ArtefactBucket string
+	PolicyKey      string `json:"-"`
+	TemplateKey    string `json:"-"`
 
 	Checksum string `json:"-"`
+}
+
+func (stack *Stack) ShouldUpload() bool {
+	return stack.ArtefactBucket != ""
 }
 
 func (stack *Stack) String() string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,8 +40,9 @@ type Stack struct {
 	Tags                  StackTags
 	TerminationProtection bool
 
-	Policy   interface{}
-	Template []byte
+	Policy          interface{}
+	Template        []byte
+	UploadArtefacts string
 
 	Checksum string `json:"-"`
 }

--- a/internal/config/mapping.go
+++ b/internal/config/mapping.go
@@ -70,7 +70,7 @@ func fromRawStack(
 		Policy:   policy,
 		Template: template,
 
-		ArtefactBucket: rawConfig.Defaults.UploadArtefacts.String(),
+		ArtefactBucket: rawConfig.Defaults.ArtefactBucket.String(),
 	}
 
 	checksum, err := CalculateChecksum(stack)

--- a/internal/config/rawConfig.go
+++ b/internal/config/rawConfig.go
@@ -1,7 +1,12 @@
 package config
 
 type RawConfig struct {
-	Stacks []*RawStack `json:"stacks"`
+	Defaults RawDefaults `json:"defaults"`
+	Stacks   []*RawStack `json:"stacks"`
+}
+
+type RawDefaults struct {
+	UploadArtefacts String `json:"uploadArtefacts" yaml:"uploadArtefacts"`
 }
 
 type RawStack struct {

--- a/internal/config/rawConfig.go
+++ b/internal/config/rawConfig.go
@@ -6,7 +6,7 @@ type RawConfig struct {
 }
 
 type RawDefaults struct {
-	UploadArtefacts String `json:"uploadArtefacts" yaml:"uploadArtefacts"`
+	ArtefactBucket String `json:"artefactBucket" yaml:"artefactBucket"`
 }
 
 type RawStack struct {

--- a/internal/stratus/s3.go
+++ b/internal/stratus/s3.go
@@ -1,0 +1,20 @@
+package stratus
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+var (
+	_ S3 = new(s3.S3)
+	_ S3 = new(S3Mock)
+)
+
+type S3 interface {
+	PutObjectWithContext(
+		aws.Context,
+		*s3.PutObjectInput,
+		...request.Option,
+	) (*s3.PutObjectOutput, error)
+}

--- a/internal/stratus/s3_mock.go
+++ b/internal/stratus/s3_mock.go
@@ -1,0 +1,88 @@
+package stratus
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"reflect"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/stretchr/testify/mock"
+)
+
+type S3Mock struct {
+	mock.Mock
+}
+
+func NewS3Mock() *S3Mock {
+	return new(S3Mock)
+}
+
+func (client *S3Mock) PutObjectWithContext(
+	_ aws.Context,
+	input *s3.PutObjectInput,
+	_ ...request.Option,
+) (*s3.PutObjectOutput, error) {
+	args := client.Called(input)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*s3.PutObjectOutput), args.Error(1)
+}
+
+func (client *S3Mock) PutObjectWithContextMatcher(
+	expected *s3.PutObjectInput,
+) func(*s3.PutObjectInput) bool {
+	return func(actual *s3.PutObjectInput) bool {
+		if expected == nil && actual == nil {
+			return true
+		}
+
+		if expected == nil ||
+			actual == nil ||
+			!reflect.DeepEqual(expected.Bucket, actual.Bucket) ||
+			!reflect.DeepEqual(expected.Key, actual.Key) {
+			fmt.Printf(
+				"S3Mock.PutObjectWithContextMatcher: expected '%+v', received '%+v'\n",
+				expected,
+				actual,
+			)
+			return false
+		}
+
+		err := compareReaders(expected.Body, actual.Body)
+		if err != nil {
+			fmt.Printf("S3Mock.PutObjectWithContextMatcher.Body: %+v\n", err)
+			return false
+		}
+
+		return true
+	}
+}
+
+func compareReaders(a, b io.Reader) error {
+	var bufferA, bufferB bytes.Buffer
+
+	teeA := io.TeeReader(a, &bufferA)
+	teeB := io.TeeReader(b, &bufferB)
+
+	dataA, err := ioutil.ReadAll(teeA)
+	if err != nil {
+		return fmt.Errorf("error reading a: %+v\n", err)
+	}
+
+	dataB, err := ioutil.ReadAll(teeB)
+	if err != nil {
+		return fmt.Errorf("error reading b: %+v\n", err)
+	}
+
+	equal := reflect.DeepEqual(dataA, dataB)
+	if !equal {
+		return fmt.Errorf("expected '%s', received '%s'", dataA, dataB)
+	}
+
+	return nil
+}

--- a/internal/stratus/utils.go
+++ b/internal/stratus/utils.go
@@ -131,3 +131,7 @@ func isStackDoesNotExistError(err error) bool {
 	return awsError.Code() == "ValidationError" &&
 		strings.Contains(awsError.Message(), "does not exist")
 }
+
+func toS3URL(bucket, key string) string {
+	return fmt.Sprintf("https://s3.amazonaws.com/%s/%s", bucket, key)
+}

--- a/samples/external-yaml/stratus.yaml
+++ b/samples/external-yaml/stratus.yaml
@@ -1,3 +1,6 @@
+defaults:
+  uploadArtefacts: s3://bucket-name/prefix
+
 stacks:
   - name: stratus-sample-external-yaml
 

--- a/samples/external-yaml/stratus.yaml
+++ b/samples/external-yaml/stratus.yaml
@@ -1,5 +1,5 @@
 defaults:
-  uploadArtefacts: sample-bucket-name
+  artefactBucket: sample-bucket-name
 
 stacks:
   - name: stratus-sample-external-yaml

--- a/samples/external-yaml/stratus.yaml
+++ b/samples/external-yaml/stratus.yaml
@@ -1,5 +1,5 @@
 defaults:
-  uploadArtefacts: s3://bucket-name/prefix
+  uploadArtefacts: sample-bucket-name
 
 stacks:
   - name: stratus-sample-external-yaml


### PR DESCRIPTION
Stack policies and templates can be uploaded to S3 with the new `defaults.artefactBucket` config option. [This is required for templates that are larger than 51,200 bytes.](https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_CreateChangeSet.html)