### PR TITLE
feat(cmd): Compare change set contents on preview

### DIFF
--- a/internal/command/preview_happy_test.go
+++ b/internal/command/preview_happy_test.go
@@ -25,7 +25,8 @@ func Test_Preview_Happy_ExistingChangeSet(t *testing.T) {
 	stack := &config.Stack{
 		Name: mockStackName,
 
-		Policy: []byte(mockStackPolicy),
+		Policy:   []byte(mockStackPolicy),
+		Template: []byte(mockStackTemplate),
 
 		Checksum: mockChecksum,
 	}
@@ -47,6 +48,20 @@ func Test_Preview_Happy_ExistingChangeSet(t *testing.T) {
 						ExecutionStatus: aws.String(cloudformation.ExecutionStatusAvailable),
 					},
 				},
+			},
+			nil,
+		).
+		On(
+			"GetTemplateWithContext",
+			&cloudformation.GetTemplateInput{
+				ChangeSetName: aws.String(mockChangeSetCreateName),
+				StackName:     aws.String(stack.Name),
+				TemplateStage: aws.String(cloudformation.TemplateStageOriginal),
+			},
+		).
+		Return(
+			&cloudformation.GetTemplateOutput{
+				TemplateBody: aws.String(mockStackTemplate),
 			},
 			nil,
 		).

--- a/internal/command/preview_happy_test.go
+++ b/internal/command/preview_happy_test.go
@@ -25,6 +25,21 @@ func Test_Preview_Happy_ExistingChangeSet(t *testing.T) {
 	stack := &config.Stack{
 		Name: mockStackName,
 
+		Capabilities: []string{
+			cloudformation.CapabilityCapabilityAutoExpand,
+			cloudformation.CapabilityCapabilityNamedIam,
+		},
+		Parameters: config.StackParameters{
+			&config.StackParameter{
+				Key:   "test-parameter-key-b",
+				Value: "test-parameter-value-b",
+			},
+			&config.StackParameter{
+				Key:   "test-parameter-key-a",
+				Value: "test-parameter-value-a",
+			},
+		},
+
 		Policy:   []byte(mockStackPolicy),
 		Template: []byte(mockStackTemplate),
 
@@ -72,7 +87,25 @@ func Test_Preview_Happy_ExistingChangeSet(t *testing.T) {
 				StackName:     aws.String(stack.Name),
 			},
 		).
-		Return(new(cloudformation.DescribeChangeSetOutput), nil).
+		Return(
+			&cloudformation.DescribeChangeSetOutput{
+				Capabilities: []*string{
+					aws.String(cloudformation.CapabilityCapabilityAutoExpand),
+					aws.String(cloudformation.CapabilityCapabilityNamedIam),
+				},
+				Parameters: []*cloudformation.Parameter{
+					&cloudformation.Parameter{
+						ParameterKey:   aws.String("test-parameter-key-a"),
+						ParameterValue: aws.String("test-parameter-value-a"),
+					},
+					&cloudformation.Parameter{
+						ParameterKey:   aws.String("test-parameter-key-b"),
+						ParameterValue: aws.String("test-parameter-value-b"),
+					},
+				},
+			},
+			nil,
+		).
 		On(
 			"DescribeStacksWithContext",
 			&cloudformation.DescribeStacksInput{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -60,6 +60,16 @@ func (stack *Stack) String() string {
 
 type StackParameters []*StackParameter
 
+func (parameters StackParameters) Contains(key, value string) bool {
+	for _, parameter := range parameters {
+		if parameter.Key == key && parameter.Value == value {
+			return true
+		}
+	}
+
+	return false
+}
+
 type StackParameter struct {
 	Key   string `json:"key"`
 	Value string `json:"value"`

--- a/internal/stratus/client.go
+++ b/internal/stratus/client.go
@@ -223,7 +223,7 @@ func (client *Client) FindExistingChangeSet(
 				return nil, err
 			}
 
-			if string(stack.Template) != *templateOutput.TemplateBody {
+			if !MatchesChangeSetContents(stack, changeSetOutput, templateOutput) {
 				// TODO: raise error to indicate tampering?
 				continue
 			}

--- a/internal/stratus/cloudFormation.go
+++ b/internal/stratus/cloudFormation.go
@@ -48,6 +48,12 @@ type CloudFormation interface {
 		...request.Option,
 	) (*cloudformation.GetStackPolicyOutput, error)
 
+	GetTemplateWithContext(
+		aws.Context,
+		*cloudformation.GetTemplateInput,
+		...request.Option,
+	) (*cloudformation.GetTemplateOutput, error)
+
 	ListChangeSetsWithContext(
 		aws.Context,
 		*cloudformation.ListChangeSetsInput,

--- a/internal/stratus/cloudFormation_mock.go
+++ b/internal/stratus/cloudFormation_mock.go
@@ -87,6 +87,18 @@ func (client *CloudFormationMock) GetStackPolicyWithContext(
 	return args.Get(0).(*cloudformation.GetStackPolicyOutput), args.Error(1)
 }
 
+func (client *CloudFormationMock) GetTemplateWithContext(
+	_ aws.Context,
+	input *cloudformation.GetTemplateInput,
+	_ ...request.Option,
+) (*cloudformation.GetTemplateOutput, error) {
+	args := client.Called(input)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*cloudformation.GetTemplateOutput), args.Error(1)
+}
+
 func (client *CloudFormationMock) ListChangeSetsWithContext(
 	_ aws.Context,
 	input *cloudformation.ListChangeSetsInput,


### PR DESCRIPTION
The `preview` command tries to find an existing change set before creating a new one. This is currently implemented by searching for an identical checksum embedded in the change set name. As such, a rogue actor could create a malicious change set that is named with the expected checksum, and it would be picked up by the `preview` command and executed by the `deploy` command.

This can be solved by comparing the _contents_ of the change sets in addition to their _names_.