### PR TITLE
fix(cmd): Match existing noop change sets

### DIFF
--- a/internal/stratus/client.go
+++ b/internal/stratus/client.go
@@ -228,6 +228,10 @@ func (client *Client) FindExistingChangeSet(
 				continue
 			}
 
+			if *summary.ExecutionStatus == cloudformation.ExecutionStatusUnavailable {
+				return nil, nil
+			}
+
 			return changeSetOutput, nil
 		}
 	}

--- a/internal/stratus/utils_test.go
+++ b/internal/stratus/utils_test.go
@@ -50,10 +50,20 @@ func Test_MatchesChangeSetSummary(t *testing.T) {
 			expected: true,
 		},
 		{
-			description: "unexpected execution status",
+			description: "noop change set",
 			summary: &cloudformation.ChangeSetSummary{
 				ChangeSetName:   aws.String(fmt.Sprintf("stratus-create-%s", expectedChecksum)),
 				ExecutionStatus: aws.String(cloudformation.ExecutionStatusUnavailable),
+				Status:          aws.String(cloudformation.ChangeSetStatusFailed),
+				StatusReason:    aws.String("The submitted information didn't contain changes. Submit different information to create a change set."),
+			},
+			expected: true,
+		},
+		{
+			description: "unexpected execution status",
+			summary: &cloudformation.ChangeSetSummary{
+				ChangeSetName:   aws.String(fmt.Sprintf("stratus-create-%s", expectedChecksum)),
+				ExecutionStatus: aws.String(cloudformation.ExecutionStatusObsolete),
 			},
 			expected: false,
 		},


### PR DESCRIPTION
The `preview` command now short circuits when it finds a matching "failed" change set that contains no changes.