### PR TITLE
feat(cmd): Stage before deploy

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -11,8 +11,8 @@ Simple layer for managing CloudFormation stacks in CI/CD.
 ```shell
 stratus --help
 
-# Preview change set
-stratus preview
+# Stage change set
+stratus stage
 
 # Deploy change set
 stratus deploy
@@ -94,7 +94,7 @@ More in link:/samples[`/samples`].
 
 | Stratus
 | ✅ binary
-| ✅ `stratus preview`
+| ✅ `stratus stage`
 | ✅ `stratus deploy`
 
 |===

--- a/internal/cli/command.go
+++ b/internal/cli/command.go
@@ -12,7 +12,7 @@ import (
 var (
 	nameToCommand = map[string]Command{
 		"delete":  command.Delete,
-		"deploy":  deployAdapter,
+		"deploy":  command.Deploy,
 		"preview": previewAdapter,
 	}
 
@@ -28,19 +28,6 @@ var (
 )
 
 type Command func(context.Context, *stratus.Client, *config.Stack) error
-
-func deployAdapter(
-	ctx context.Context,
-	client *stratus.Client,
-	stack *config.Stack,
-) (err error) {
-	diff, err := command.Preview(ctx, client, stack)
-	if err != nil {
-		return err
-	}
-
-	return command.Deploy(ctx, client, stack, diff)
-}
 
 func previewAdapter(
 	ctx context.Context,

--- a/internal/cli/command.go
+++ b/internal/cli/command.go
@@ -11,9 +11,9 @@ import (
 
 var (
 	nameToCommand = map[string]Command{
-		"delete":  command.Delete,
-		"deploy":  command.Deploy,
-		"preview": previewAdapter,
+		"delete": command.Delete,
+		"deploy": command.Deploy,
+		"stage":  stageAdapter,
 	}
 
 	commandNames = func() string {
@@ -29,11 +29,11 @@ var (
 
 type Command func(context.Context, *stratus.Client, *config.Stack) error
 
-func previewAdapter(
+func stageAdapter(
 	ctx context.Context,
 	client *stratus.Client,
 	stack *config.Stack,
 ) (err error) {
-	_, err = command.Preview(ctx, client, stack)
+	_, err = command.Stage(ctx, client, stack)
 	return
 }

--- a/internal/command/deploy.go
+++ b/internal/command/deploy.go
@@ -10,14 +10,20 @@ func Deploy(
 	ctx context.Context,
 	client *stratus.Client,
 	stack *config.Stack,
-	diff *stratus.Diff,
 ) error {
 	output := context.Output(ctx)
 
-	if diff.HasChangeSet() {
+	output <- "Find existing change set"
+
+	changeSet, err := client.FindExistingChangeSet(ctx, stack)
+	if err != nil {
+		return err
+	}
+
+	if changeSet != nil {
 		output <- "Execute change set"
 
-		err := client.ExecuteChangeSet(ctx, stack, *diff.ChangeSet.ChangeSetName)
+		err = client.ExecuteChangeSet(ctx, stack, *changeSet.ChangeSetName)
 		if err != nil {
 			return err
 		}
@@ -25,7 +31,7 @@ func Deploy(
 
 	output <- "Set stack policy"
 
-	err := client.SetStackPolicy(ctx, stack)
+	err = client.SetStackPolicy(ctx, stack)
 	if err != nil {
 		return err
 	}

--- a/internal/command/stage.go
+++ b/internal/command/stage.go
@@ -6,7 +6,7 @@ import (
 	"github.com/72636c/stratus/internal/stratus"
 )
 
-func Preview(
+func Stage(
 	ctx context.Context,
 	client *stratus.Client,
 	stack *config.Stack,

--- a/internal/command/stage_happy_test.go
+++ b/internal/command/stage_happy_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/72636c/stratus/internal/stratus"
 )
 
-func Test_Preview_Happy_CreateChangeSet(t *testing.T) {
+func Test_Stage_Happy_CreateChangeSet(t *testing.T) {
 	assert := assert.New(t)
 
 	stack := &config.Stack{
@@ -111,11 +111,11 @@ func Test_Preview_Happy_CreateChangeSet(t *testing.T) {
 
 	client := stratus.NewClient(cfn, nil)
 
-	_, err := command.Preview(context.Background(), client, stack)
+	_, err := command.Stage(context.Background(), client, stack)
 	assert.NoError(err)
 }
 
-func Test_Preview_Happy_NoopChangeSet(t *testing.T) {
+func Test_Stage_Happy_NoopChangeSet(t *testing.T) {
 	assert := assert.New(t)
 
 	stack := &config.Stack{
@@ -199,11 +199,11 @@ func Test_Preview_Happy_NoopChangeSet(t *testing.T) {
 
 	client := stratus.NewClient(cfn, nil)
 
-	_, err := command.Preview(context.Background(), client, stack)
+	_, err := command.Stage(context.Background(), client, stack)
 	assert.NoError(err)
 }
 
-func Test_Preview_Happy_NoopChangeSet_UploadArtefacts(t *testing.T) {
+func Test_Stage_Happy_NoopChangeSet_UploadArtefacts(t *testing.T) {
 	assert := assert.New(t)
 
 	stack := &config.Stack{
@@ -321,11 +321,11 @@ func Test_Preview_Happy_NoopChangeSet_UploadArtefacts(t *testing.T) {
 
 	client := stratus.NewClient(cfn, s3Client)
 
-	_, err := command.Preview(context.Background(), client, stack)
+	_, err := command.Stage(context.Background(), client, stack)
 	assert.NoError(err)
 }
 
-func Test_Preview_Happy_UpdateChangeSet(t *testing.T) {
+func Test_Stage_Happy_UpdateChangeSet(t *testing.T) {
 	assert := assert.New(t)
 
 	stack := &config.Stack{
@@ -403,6 +403,6 @@ func Test_Preview_Happy_UpdateChangeSet(t *testing.T) {
 
 	client := stratus.NewClient(cfn, nil)
 
-	_, err := command.Preview(context.Background(), client, stack)
+	_, err := command.Stage(context.Background(), client, stack)
 	assert.NoError(err)
 }

--- a/internal/stratus/client.go
+++ b/internal/stratus/client.go
@@ -225,8 +225,10 @@ func (client *Client) FindExistingChangeSet(
 			}
 
 			if !MatchesChangeSetContents(stack, changeSetOutput, templateOutput) {
-				// TODO: raise error to indicate tampering?
-				continue
+				return nil, fmt.Errorf(
+					"change set '%s' has been modified",
+					*summary.ChangeSetName,
+				)
 			}
 
 			if *summary.ExecutionStatus == cloudformation.ExecutionStatusUnavailable {

--- a/internal/stratus/client.go
+++ b/internal/stratus/client.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -189,7 +190,7 @@ func (client *Client) FindExistingChangeSet(
 ) (*cloudformation.DescribeChangeSetOutput, error) {
 	listOutput, err := client.listChangeSets(ctx, stack)
 	if isStackDoesNotExistError(err) {
-		return nil, nil
+		return nil, fmt.Errorf("stack '%s' does not exist", stack.Name)
 	}
 	if err != nil {
 		return nil, err
@@ -236,7 +237,7 @@ func (client *Client) FindExistingChangeSet(
 		}
 	}
 
-	return nil, nil
+	return nil, fmt.Errorf("change set '*%s*' does not exist", stack.Checksum)
 }
 
 func (client *Client) SetStackPolicy(


### PR DESCRIPTION
Before:

1. ~~`stratus preview`~~ (provides no guarantees)
1. ~~Merge PR, unblock pipeline, etc.~~ (provides no guarantees)
1. `stratus deploy` (can create and apply a new change set)

After:

1. `stratus stage`
1. Merge PR, unblock pipeline, etc.
1. `stratus deploy` (can only apply the staged change set)

BREAKING CHANGE: the preview command is now named stage to better
reflect that it is a prerequisite to the deploy command.

BREAKING CHANGE: the deploy command now requires the change set to
exist beforehand. This ensures that it will only execute the changes
that were previously staged and reviewed, and not any new surprises.
