### PR TITLE
feat(pkg): Use distroless for base image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -23,6 +23,24 @@ steps:
           - pull_request
           - tag
 
+  - name: publish (base)
+    image: plugins/docker
+    depends_on:
+      - clone
+    settings:
+      password:
+        from_secret: docker-hub.password
+      repo: 72636c/stratus
+      tags: latest-base
+      target: final-base
+      username:
+        from_secret: docker-hub.username
+    when:
+      branch:
+        - master
+      event:
+        - push
+
   - name: publish (static)
     image: plugins/docker
     depends_on:
@@ -43,24 +61,6 @@ steps:
       event:
         - push
 
-  - name: publish (busybox)
-    image: plugins/docker
-    depends_on:
-      - clone
-    settings:
-      password:
-        from_secret: docker-hub.password
-      repo: 72636c/stratus
-      tags: latest-busybox
-      target: final-busybox
-      username:
-        from_secret: docker-hub.username
-    when:
-      branch:
-        - master
-      event:
-        - push
-
 ---
 kind: signature
-hmac: c62534567f9d79f65082bf6bc179648463d856e95a2ee0e3eb7bb8d41d549b75
+hmac: 576eb13afced812f7dbe55379f91b92fbaa41bbb6ac8b6b6429d61433272a89c

--- a/.drone.yml
+++ b/.drone.yml
@@ -43,7 +43,7 @@ steps:
       event:
         - push
 
-  - name: publish (alpine)
+  - name: publish (busybox)
     image: plugins/docker
     depends_on:
       - clone
@@ -51,8 +51,8 @@ steps:
       password:
         from_secret: docker-hub.password
       repo: 72636c/stratus
-      tags: latest-alpine
-      target: final-alpine
+      tags: latest-busybox
+      target: final-busybox
       username:
         from_secret: docker-hub.username
     when:
@@ -63,4 +63,4 @@ steps:
 
 ---
 kind: signature
-hmac: 10adaa0b39096ec9abe053c56316c7e8bae24c12a631fb4b0c8b03944d73645b
+hmac: c62534567f9d79f65082bf6bc179648463d856e95a2ee0e3eb7bb8d41d549b75

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,7 @@ USER nobody:nobody
 ENTRYPOINT ["/bin/stratus"]
 CMD ["--help"]
 
-FROM alpine:latest AS final-alpine
-
-RUN apk add --no-cache ca-certificates
+FROM gcr.io/distroless/base:debug AS final-busybox
 
 COPY --from=builder /tmp/group /tmp/passwd /etc/
 
@@ -37,5 +35,4 @@ COPY --from=builder /app /bin/stratus
 
 USER nobody:nobody
 
-ENTRYPOINT ["/bin/stratus"]
-CMD ["--help"]
+ENTRYPOINT ["/busybox/sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,16 @@ COPY stratus.go ./
 
 RUN CGO_ENABLED=0 go build -installsuffix 'static' -o /app .
 
+FROM gcr.io/distroless/base:debug AS final-base
+
+COPY --from=builder /tmp/group /tmp/passwd /etc/
+
+COPY --from=builder /app /bin/stratus
+
+USER nobody:nobody
+
+ENTRYPOINT ["/busybox/sh"]
+
 FROM gcr.io/distroless/static:latest AS final-static
 
 COPY --from=builder /tmp/group /tmp/passwd /etc/
@@ -26,13 +36,3 @@ USER nobody:nobody
 
 ENTRYPOINT ["/bin/stratus"]
 CMD ["--help"]
-
-FROM gcr.io/distroless/base:debug AS final-busybox
-
-COPY --from=builder /tmp/group /tmp/passwd /etc/
-
-COPY --from=builder /app /bin/stratus
-
-USER nobody:nobody
-
-ENTRYPOINT ["/busybox/sh"]


### PR DESCRIPTION
The `distroless/base:debug` image contains BusyBox. This should be a
sufficiently minimal image to support environments like Drone which
require a shell, replacing the old `alpine:latest`-based image.