### PR TITLE
feat(cfg): Block sensitive env substitution

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -19,6 +19,7 @@ steps:
         exclude:
           - master
       event:
+        - pull_request
         - push
 
   - name: test
@@ -35,6 +36,7 @@ steps:
         exclude:
           - master
       event:
+        - pull_request
         - push
 
   - name: push (base)
@@ -77,4 +79,4 @@ steps:
 
 ---
 kind: signature
-hmac: 514108390b23d037b12543b86af13f5039d576843aeab4a29b3519547f0bd4f6
+hmac: 0be9c7348f779ea2065708270dfda91ac809d1fb56d5ba86f8d96d66bace0d97

--- a/internal/config/unmarshal_test.go
+++ b/internal/config/unmarshal_test.go
@@ -58,6 +58,11 @@ func Test_Resolve(t *testing.T) {
 			expected:    "serious-resource-name",
 		},
 		{
+			description:   "blocked environment variable",
+			input:         "{{env:aWs_SeCreT_aCcEsS_kEy}}",
+			expectedError: "is blocked",
+		},
+		{
 			description:   "environment variable not set",
 			input:         "{{env:UNSET_1}}",
 			expectedError: "not set",


### PR DESCRIPTION
BREAKING CHANGE: {{env:BLAH}} substitution can now error if a sensitive
variable is detected. This is currently limited to the standard AWS key
and token variables.