### PR TITLE
chore(ci): Fix pull_request event

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -15,9 +15,6 @@ steps:
       dry_run: true
       repo: 72636c/stratus
     when:
-      branch:
-        exclude:
-          - master
       event:
         - pull_request
         - push
@@ -32,9 +29,6 @@ steps:
     depends_on:
       - clone
     when:
-      branch:
-        exclude:
-          - master
       event:
         - pull_request
         - push
@@ -79,4 +73,4 @@ steps:
 
 ---
 kind: signature
-hmac: 0be9c7348f779ea2065708270dfda91ac809d1fb56d5ba86f8d96d66bace0d97
+hmac: 8aecfe8b5d4a0f71b318392ec03a78e7fe91d295545b47a28ea2f0ab28f79edc


### PR DESCRIPTION
The pull_request event is triggered with a target branch of master. The
simple workaround is to enable builds on master rather than creating
separate steps for pushes and pull requests.