### PR TITLE
fix: Allow empty environment variables

### DIFF
--- a/internal/config/unmarshal.go
+++ b/internal/config/unmarshal.go
@@ -63,11 +63,11 @@ func envMapper(placeholder string) (string, error) {
 	}
 
 	resolved, ok := os.LookupEnv(placeholder)
-	if !ok {
-		// LookupEnv doesn't seem to correct detect variables that have been set to
-		// empty, at least on macOS.
-		// return "", fmt.Errorf("environment variable '%s' not set", placeholder)
-	}
+	// LookupEnv doesn't seem to correct detect variables that have been set to
+	// empty, at least on macOS.
+	// if !ok {
+	// 	return "", fmt.Errorf("environment variable '%s' not set", placeholder)
+	// }
 
 	return resolved, nil
 }

--- a/internal/config/unmarshal.go
+++ b/internal/config/unmarshal.go
@@ -64,7 +64,9 @@ func envMapper(placeholder string) (string, error) {
 
 	resolved, ok := os.LookupEnv(placeholder)
 	if !ok {
-		return "", fmt.Errorf("environment variable '%s' not set", placeholder)
+		// LookupEnv doesn't seem to correct detect variables that have been set to
+		// empty, at least on macOS.
+		// return "", fmt.Errorf("environment variable '%s' not set", placeholder)
 	}
 
 	return resolved, nil

--- a/internal/config/unmarshal_test.go
+++ b/internal/config/unmarshal_test.go
@@ -63,9 +63,9 @@ func Test_Resolve(t *testing.T) {
 			expectedError: "is blocked",
 		},
 		{
-			description:   "environment variable not set",
-			input:         "{{env:UNSET_1}}",
-			expectedError: "not set",
+			description: "environment variable not set",
+			input:       "{{env:UNSET_1}}",
+			expected:    "",
 		},
 		{
 			description:   "malformed placeholder",


### PR DESCRIPTION
For some reason, os.LookupEnv appears to be playing up on my machine and is refusing to recognise a variable that has been set to empty string. The check is more of a matter of convenience, so it can be commented out until a more permanent solution can be found.