### PR TITLE
fix: Handle default parameters on deploy

### DIFF
--- a/internal/stratus/utils.go
+++ b/internal/stratus/utils.go
@@ -163,12 +163,16 @@ func matchesChangeSetParameters(
 		}
 	}
 
-	if len(expected) != len(actualValues) {
+	// allow change set parameters to be a superset of config parameters, as they
+	// may include default values. loosening this check avoids the complexity of
+	// parsing default values out of the CloudFormation template.
+
+	if len(expected) > len(actualValues) {
 		return false
 	}
 
-	for _, value := range actualValues {
-		if !expected.Contains(value.Key, value.Value) {
+	for _, value := range expected {
+		if !actualValues.Contains(value.Key, value.Value) {
 			return false
 		}
 	}


### PR DESCRIPTION
A staged change set may contain a superset of the parameters defined in
the config file due to default values. Loosen the matcher logic to avoid
false positives:

```text
change set 'xxx' has been modified
```