### PR TITLE
fix: Use YAML log output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,8 @@ module github.com/72636c/stratus
 
 require (
 	github.com/aws/aws-sdk-go v1.16.26
+	github.com/logrusorgru/aurora v0.0.0-20190428105938-cea283e61946
 	github.com/stretchr/testify v1.3.0
-	github.com/tidwall/pretty v0.0.0-20180105212114-65a9db5fad51
 	golang.org/x/net v0.0.0-20190227160552-c95aed5357e7 // indirect
 	golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4
 	golang.org/x/text v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,14 +4,14 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
+github.com/logrusorgru/aurora v0.0.0-20190428105938-cea283e61946 h1:z+WaKrgu3kCpcdnbK9YG+JThpOCd1nU5jO5ToVmSlR4=
+github.com/logrusorgru/aurora v0.0.0-20190428105938-cea283e61946/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/tidwall/pretty v0.0.0-20180105212114-65a9db5fad51 h1:BP2bjP495BBPaBcS5rmqviTfrOkN5rO5ceKAMRZCRFc=
-github.com/tidwall/pretty v0.0.0-20180105212114-65a9db5fad51/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 golang.org/x/net v0.0.0-20190227160552-c95aed5357e7 h1:C2F/nMkR/9sfUTpvR3QrjBuTdvMUC/cFajkphs1YLQo=
 golang.org/x/net v0.0.0-20190227160552-c95aed5357e7/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 h1:YUO/7uOKsKeq9UokNS62b8FYywz3ker1l1vDZRCRefw=

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -122,7 +122,7 @@ func (app *App) Do(ctx context.Context) error {
 		return fmt.Errorf("stack '%s' not found in config", app.stackName)
 	}
 
-	app.logger.Title("Stratus.StackConfig")
+	app.logger.Title("Load config")
 	app.logger.Data(stack)
 
 	return app.command(context.WithLogger(ctx, app.logger), app.client, stack)
@@ -132,7 +132,7 @@ func (app *App) doAll(ctx context.Context) error {
 	for index := 0; index < len(app.cfg.Stacks); index++ {
 		stack := app.cfg.Stacks[index]
 
-		app.logger.Title("Stratus.[%d].StackConfig", index)
+		app.logger.Title("Load config %d", index)
 		app.logger.Data(stack)
 
 		err := app.command(context.WithLogger(ctx, app.logger), app.client, stack)

--- a/internal/stratus/utils.go
+++ b/internal/stratus/utils.go
@@ -70,21 +70,24 @@ func getChangeSetType(name string) (ChangeSetType, error) {
 }
 
 func formatStackEvent(event *cloudformation.StackEvent) string {
-	resourceStatusReason := ""
+	builder := new(strings.Builder)
 
-	if event.ResourceStatusReason != nil {
-		resourceStatusReason = fmt.Sprintf("\n└ %s", *event.ResourceStatusReason)
-	}
-
-	return fmt.Sprintf(
-		"%-*s %-*s %s%s",
+	summary := fmt.Sprintf(
+		"%-*s %-*s %s",
 		maxStackStatusLength,
 		*event.ResourceStatus,
 		maxStackResourceTypeLength,
 		*event.ResourceType,
 		*event.LogicalResourceId,
-		resourceStatusReason,
 	)
+	builder.WriteString(summary)
+
+	if event.ResourceStatusReason != nil {
+		details := fmt.Sprintf("\n└ %s", *event.ResourceStatusReason)
+		builder.WriteString(details)
+	}
+
+	return builder.String()
 }
 
 func isAcceptableChangeSetStatus(

--- a/internal/stratus/utils.go
+++ b/internal/stratus/utils.go
@@ -29,6 +29,10 @@ var (
 		".yaml": "application/x-yaml; charset=utf-8",
 		".yml":  "application/x-yaml; charset=utf-8",
 	}
+
+	// best guesses
+	maxStackStatusLength       = len(cloudformation.StackStatusUpdateRollbackCompleteCleanupInProgress)
+	maxStackResourceTypeLength = len("AWS::KinesisAnalyticsV2::ApplicationCloudWatchLoggingOption")
 )
 
 func MatchesChangeSetContents(
@@ -66,20 +70,20 @@ func getChangeSetType(name string) (ChangeSetType, error) {
 }
 
 func formatStackEvent(event *cloudformation.StackEvent) string {
-	resourceStatus := new(strings.Builder)
-
-	resourceStatus.WriteString(*event.ResourceStatus)
+	resourceStatusReason := ""
 
 	if event.ResourceStatusReason != nil {
-		resourceStatus.WriteString(" ")
-		resourceStatus.WriteString(*event.ResourceStatusReason)
+		resourceStatusReason = fmt.Sprintf("\n└ %s", *event.ResourceStatusReason)
 	}
 
 	return fmt.Sprintf(
-		"%s [%s] %s",
+		"%-*s %-*s %s%s",
+		maxStackStatusLength,
+		*event.ResourceStatus,
+		maxStackResourceTypeLength,
 		*event.ResourceType,
 		*event.LogicalResourceId,
-		resourceStatus.String(),
+		resourceStatusReason,
 	)
 }
 


### PR DESCRIPTION
In lieu of a fancy encoder/printer:

- Simply marshal non-string logs as YAML
- Add fixed padding for stack event logs
- Ignore `--output` options until colour-aware encoding is implemented

Example output:

```text
Load config
───────────
ArtefactBucket: sample-bucket-name
Capabilities: []
Name: stratus-sample-external-yaml
Parameters: []
Policy: ewogICJTdGF0ZW1lbnQiOiBbCiAgICB7CiAgICAgICJFZmZlY3QiOiAiQWxsb3ciLAogICAgICAiQWN0aW9uIjogIlVwZGF0ZToqIiwKICAgICAgIlByaW5jaXBhbCI6ICIqIiwKICAgICAgIlJlc291cmNlIjogIioiCiAgICB9CiAgXQp9Cg==
Tags: []
Template: QVdTVGVtcGxhdGVGb3JtYXRWZXJzaW9uOiAnMjAxMC0wOS0wOScKCkRlc2NyaXB0aW9uOiBTdHJhdHVzIEV4dGVybmFsIFlBTUwgU2FtcGxlCgpSZXNvdXJjZXM6CiAgU2FtcGxlUGFyYW1ldGVyOgogICAgVHlwZTogQVdTOjpTU006OlBhcmFtZXRlcgogICAgUHJvcGVydGllczoKICAgICAgVHlwZTogU3RyaW5nCiAgICAgIFZhbHVlOiBIZWxsbyB3b3JsZCEhISEK
TerminationProtection: false

Find existing change set
────────────────────────

Execute change set
──────────────────
UPDATE_IN_PROGRESS                           AWS::CloudFormation::Stack                                  stratus-sample-external-yaml
└ User Initiated
UPDATE_IN_PROGRESS                           AWS::SSM::Parameter                                         SampleParameter
UPDATE_COMPLETE                              AWS::SSM::Parameter                                         SampleParameter
UPDATE_COMPLETE_CLEANUP_IN_PROGRESS          AWS::CloudFormation::Stack                                  stratus-sample-external-yaml
UPDATE_COMPLETE                              AWS::CloudFormation::Stack                                  stratus-sample-external-yaml

Describe outputs
────────────────
null

Set stack policy
────────────────

Update termination protection
─────────────────────────────
```