### PR TITLE
fix: Suppress byte arrays from config output

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,8 +52,8 @@ type Stack struct {
 	Tags                  StackTags
 	TerminationProtection bool
 
-	Policy   []byte
-	Template []byte
+	Policy   []byte `json:"-"`
+	Template []byte `json:"-"`
 
 	ArtefactBucket string
 	PolicyKey      string `json:"-"`


### PR DESCRIPTION
These were hardly useful:

```text
Load config
───────────
...
Policy: ewogICJTdGF0ZW1lbnQiOiBbCiAgICB7CiAgICAgICJFZmZlY3QiOiAiQWxsb3ciLAogICAgICAiQWN0aW9uIjogIlVwZGF0ZToqIiwKICAgICAgIlByaW5jaXBhbCI6ICIqIiwKICAgICAgIlJlc291cmNlIjogIioiCiAgICB9CiAgXQp9Cg==
Template: QVdTVGVtcGxhdGVGb3JtYXRWZXJzaW9uOiAnMjAxMC0wOS0wOScKCkRlc2NyaXB0aW9uOiBTdHJhdHVzIEV4dGVybmFsIFlBTUwgU2FtcGxlCgpSZXNvdXJjZXM6CiAgU2FtcGxlUGFyYW1ldGVyOgogICAgVHlwZTogQVdTOjpTU006OlBhcmFtZXRlcgogICAgUHJvcGVydGllczoKICAgICAgVHlwZTogU3RyaW5nCiAgICAgIFZhbHVlOiBIZWxsbyB3b3JsZCEhISEK
```