### PR TITLE
fix: Revert #52

### DIFF
--- a/internal/config/checksum_test.go
+++ b/internal/config/checksum_test.go
@@ -15,6 +15,16 @@ func Test_CalculateChecksum(t *testing.T) {
 		expected    string
 	}{
 		{
+			description: "config.Stack",
+			input: func() interface{} {
+				return &config.Stack{
+					Policy:   []byte("a"),
+					Template: []byte("b"),
+				}
+			},
+			expected: "5dc046d563a19c16dfae96d8b530873f7b6a758af3e68bde7aefa3d96790770c",
+		},
+		{
 			description: "map",
 			input: func() interface{} {
 				return map[string]interface{}{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,8 +52,8 @@ type Stack struct {
 	Tags                  StackTags
 	TerminationProtection bool
 
-	Policy   []byte `json:"-"`
-	Template []byte `json:"-"`
+	Policy   []byte
+	Template []byte
 
 	ArtefactBucket string
 	PolicyKey      string `json:"-"`


### PR DESCRIPTION
These fields are important for calculating the changeset checksum.