### PR TITLE
fix: Suppress byte arrays from config output

### DIFF
--- a/internal/config/checksum_test.go
+++ b/internal/config/checksum_test.go
@@ -15,12 +15,14 @@ func Test_CalculateChecksum(t *testing.T) {
 		expected    string
 	}{
 		{
-			description: "config.Stack",
+			description: "config.Stack.Hashable",
 			input: func() interface{} {
-				return &config.Stack{
+				stack := &config.Stack{
 					Policy:   []byte("a"),
 					Template: []byte("b"),
 				}
+
+				return stack.Hashable()
 			},
 			expected: "5dc046d563a19c16dfae96d8b530873f7b6a758af3e68bde7aefa3d96790770c",
 		},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,14 +52,38 @@ type Stack struct {
 	Tags                  StackTags
 	TerminationProtection bool
 
-	Policy   []byte
-	Template []byte
+	Policy   []byte `json:"-"`
+	Template []byte `json:"-"`
 
 	ArtefactBucket string
-	PolicyKey      string `json:"-"`
-	TemplateKey    string `json:"-"`
+	PolicyKey      string
+	TemplateKey    string
 
-	Checksum string `json:"-"`
+	Checksum string
+}
+
+func (stack *Stack) Hashable() interface{} {
+	if stack == nil {
+		return stack
+	}
+
+	return struct {
+		Name string
+
+		Capabilities          []string
+		Parameters            StackParameters
+		Tags                  StackTags
+		TerminationProtection bool
+
+		Policy   []byte
+		Template []byte
+
+		ArtefactBucket string
+		PolicyKey      string `json:"-"`
+		TemplateKey    string `json:"-"`
+
+		Checksum string `json:"-"`
+	}(*stack)
 }
 
 func (stack *Stack) ShouldUpload() bool {

--- a/internal/config/mapping.go
+++ b/internal/config/mapping.go
@@ -73,7 +73,7 @@ func fromRawStack(
 		ArtefactBucket: rawConfig.Defaults.ArtefactBucket.String(),
 	}
 
-	checksum, err := CalculateChecksum(stack)
+	checksum, err := CalculateChecksum(stack.Hashable())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Take two of #52, but without breaking checksums this time.