### PR TITLE
fix: Poll for stack events after operation

### DIFF
--- a/internal/stratus/utils.go
+++ b/internal/stratus/utils.go
@@ -263,3 +263,11 @@ func toStringList(xs []*string) []string {
 
 	return slice
 }
+
+func toWaiterOption(fn func()) request.WaiterOption {
+	return request.WithWaiterRequestOptions(
+		func(*request.Request) {
+			fn()
+		},
+	)
+}


### PR DESCRIPTION
Try to ensure that stack events occurring after the final waiter option invocation are still logged.