### PR TITLE
Allow `deploy` without prior `stage` when `FORCE_DEPLOY` environment is `true`

### DIFF
--- a/internal/cli/command.go
+++ b/internal/cli/command.go
@@ -34,6 +34,6 @@ func stageAdapter(
 	client *stratus.Client,
 	stack *config.Stack,
 ) (err error) {
-	_, err = command.Stage(ctx, client, stack)
+	_, _, err = command.Stage(ctx, client, stack)
 	return
 }

--- a/internal/command/deploy.go
+++ b/internal/command/deploy.go
@@ -1,6 +1,8 @@
 package command
 
 import (
+	"os"
+
 	"github.com/72636c/stratus/internal/config"
 	"github.com/72636c/stratus/internal/context"
 	"github.com/72636c/stratus/internal/stratus"
@@ -18,9 +20,14 @@ func Deploy(
 	changeSet, err := client.FindExistingChangeSet(ctx, stack)
 
 	if err != nil {
-		logger.Title("Could not find existing change set. Creating new change set.")
+		if os.Getenv("FORCE_DEPLOY") == "true" {
+			logger.Title("Could not find existing change set. FORCE_DEPLOY is true, so creating a new change set.")
 
-		if _, changeSet, err = Stage(ctx, client, stack); err != nil {
+			if _, changeSet, err = Stage(ctx, client, stack); err != nil {
+				return err
+			}
+		} else {
+			logger.Title("Could not find existing change set, exiting. To force a deployment with a new change set, set FORCE_DEPLOY=true and retry.")
 			return err
 		}
 	}

--- a/internal/command/deploy.go
+++ b/internal/command/deploy.go
@@ -16,8 +16,13 @@ func Deploy(
 	logger.Title("Find existing change set")
 
 	changeSet, err := client.FindExistingChangeSet(ctx, stack)
+
 	if err != nil {
-		return err
+		logger.Title("Could not find existing change set. Creating new change set.")
+
+		if _, changeSet, err = Stage(ctx, client, stack); err != nil {
+			return err
+		}
 	}
 
 	if changeSet != nil {

--- a/internal/command/deploy_happy_test.go
+++ b/internal/command/deploy_happy_test.go
@@ -513,3 +513,163 @@ func Test_Deploy_Happy_NoopChangeSet_UploadArtefacts(t *testing.T) {
 	err := command.Deploy(context.Background(), client, stack)
 	assert.NoError(err)
 }
+
+func Test_Deploy_Happy_ImplicitStage(t *testing.T) {
+	assert := assert.New(t)
+
+	stack := &config.Stack{
+		Name: mockStackName,
+
+		Capabilities:          make([]string, 0),
+		Parameters:            make(config.StackParameters, 0),
+		TerminationProtection: true,
+
+		Policy:   []byte(mockStackPolicy),
+		Template: []byte(mockStackTemplate),
+
+		Checksum: mockChecksum,
+	}
+
+	cfn := stratus.NewCloudFormationMock()
+	defer cfn.AssertExpectations(t)
+	cfn.
+		On(
+			"ListChangeSetsWithContext",
+			&cloudformation.ListChangeSetsInput{
+				StackName: aws.String(stack.Name),
+			},
+		).
+		Return(
+			&cloudformation.ListChangeSetsOutput{
+				Summaries: []*cloudformation.ChangeSetSummary{},
+			},
+			nil,
+		).Once().
+		On(
+			"ValidateTemplateWithContext",
+			&cloudformation.ValidateTemplateInput{
+				TemplateBody: aws.String(string(stack.Template)),
+			},
+		).
+		Return(nil, nil).
+		On(
+			"CreateChangeSetWithContext",
+			&cloudformation.CreateChangeSetInput{
+				Capabilities:        make([]*string, 0),
+				ChangeSetName:       aws.String(mockChangeSetUpdateName),
+				ChangeSetType:       aws.String(cloudformation.ChangeSetTypeUpdate),
+				StackName:           aws.String(stack.Name),
+				Parameters:          make([]*cloudformation.Parameter, 0),
+				Tags:                make([]*cloudformation.Tag, 0),
+				TemplateBody:        aws.String(string(stack.Template)),
+				UsePreviousTemplate: aws.Bool(false),
+			},
+		).
+		Return(nil, nil).
+		On(
+			"WaitUntilChangeSetCreateCompleteWithContext",
+			&cloudformation.DescribeChangeSetInput{
+				ChangeSetName: aws.String(mockChangeSetUpdateName),
+				StackName:     aws.String(stack.Name),
+			},
+		).
+		Return(nil).
+		On(
+			"DescribeChangeSetWithContext",
+			&cloudformation.DescribeChangeSetInput{
+				ChangeSetName: aws.String(mockChangeSetUpdateName),
+				StackName:     aws.String(stack.Name),
+			},
+		).
+		Return(
+			&cloudformation.DescribeChangeSetOutput{
+				ChangeSetName: aws.String(mockChangeSetUpdateName),
+				Capabilities:  make([]*string, 0),
+				Parameters:    make([]*cloudformation.Parameter, 0),
+			},
+			nil,
+		).
+		On(
+			"DescribeStacksWithContext",
+			&cloudformation.DescribeStacksInput{
+				StackName: aws.String(stack.Name),
+			},
+		).
+		Return(
+			&cloudformation.DescribeStacksOutput{
+				Stacks: []*cloudformation.Stack{
+					{
+						EnableTerminationProtection: aws.Bool(false),
+					},
+				},
+			},
+			nil,
+		).
+		On(
+			"GetStackPolicyWithContext",
+			&cloudformation.GetStackPolicyInput{
+				StackName: aws.String(stack.Name),
+			},
+		).
+		Return(nil, nil).
+		On(
+			"DescribeStackEventsWithContext",
+			&cloudformation.DescribeStackEventsInput{
+				StackName: aws.String(stack.Name),
+			},
+		).
+		Return(
+			&cloudformation.DescribeStackEventsOutput{
+				StackEvents: make([]*cloudformation.StackEvent, 0),
+			},
+			nil,
+		).
+		On(
+			"ExecuteChangeSetWithContext",
+			&cloudformation.ExecuteChangeSetInput{
+				ChangeSetName: aws.String(mockChangeSetUpdateName),
+				StackName:     aws.String(mockStackName),
+			},
+		).
+		Return(nil, nil).
+		On(
+			"DescribeStackEventsWithContext",
+			&cloudformation.DescribeStackEventsInput{
+				StackName: aws.String(stack.Name),
+			},
+		).
+		Return(
+			&cloudformation.DescribeStackEventsOutput{
+				StackEvents: make([]*cloudformation.StackEvent, 0),
+			},
+			nil,
+		).
+		On(
+			"WaitUntilStackUpdateCompleteWithContext",
+			&cloudformation.DescribeStacksInput{
+				StackName: aws.String(mockStackName),
+			},
+		).
+		Return(nil).
+		On(
+			"SetStackPolicyWithContext",
+			&cloudformation.SetStackPolicyInput{
+				StackName:       aws.String(mockStackName),
+				StackPolicyBody: aws.String(mockStackPolicy),
+			},
+		).
+		Return(nil, nil).
+		On(
+			"UpdateTerminationProtectionWithContext",
+			&cloudformation.UpdateTerminationProtectionInput{
+				EnableTerminationProtection: aws.Bool(true),
+				StackName:                   aws.String(mockStackName),
+			},
+		).
+		Return(nil, nil)
+
+	client := stratus.NewClient(cfn, nil)
+
+	err := command.Deploy(context.Background(), client, stack)
+	assert.NoError(err)
+}

--- a/internal/command/deploy_test.go
+++ b/internal/command/deploy_test.go
@@ -361,9 +361,12 @@ func Test_Deploy_Happy_NoopChangeSet(t *testing.T) {
 		).
 		Return(
 			&cloudformation.DescribeChangeSetOutput{
-				ChangeSetName: aws.String(mockChangeSetUpdateName),
-				Capabilities:  make([]*string, 0),
-				Parameters:    make([]*cloudformation.Parameter, 0),
+				ChangeSetName:   aws.String(mockChangeSetUpdateName),
+				Capabilities:    make([]*string, 0),
+				Parameters:      make([]*cloudformation.Parameter, 0),
+				ExecutionStatus: aws.String(cloudformation.ExecutionStatusUnavailable),
+				Status:          aws.String(cloudformation.ChangeSetStatusFailed),
+				StatusReason:    aws.String("The submitted information didn't contain changes. Submit different information to create a change set."),
 			},
 			nil,
 		).
@@ -470,9 +473,12 @@ func Test_Deploy_Happy_NoopChangeSet_UploadArtefacts(t *testing.T) {
 		).
 		Return(
 			&cloudformation.DescribeChangeSetOutput{
-				ChangeSetName: aws.String(mockChangeSetUpdateName),
-				Capabilities:  make([]*string, 0),
-				Parameters:    make([]*cloudformation.Parameter, 0),
+				ChangeSetName:   aws.String(mockChangeSetUpdateName),
+				Capabilities:    make([]*string, 0),
+				Parameters:      make([]*cloudformation.Parameter, 0),
+				ExecutionStatus: aws.String(cloudformation.ExecutionStatusUnavailable),
+				Status:          aws.String(cloudformation.ChangeSetStatusFailed),
+				StatusReason:    aws.String("The submitted information didn't contain changes. Submit different information to create a change set."),
 			},
 			nil,
 		).

--- a/internal/command/stage_happy_test.go
+++ b/internal/command/stage_happy_test.go
@@ -168,8 +168,9 @@ func Test_Stage_Happy_NoopChangeSet(t *testing.T) {
 		).
 		Return(
 			&cloudformation.DescribeChangeSetOutput{
-				Status:       aws.String(cloudformation.ChangeSetStatusFailed),
-				StatusReason: aws.String("The submitted information didn't contain changes. Submit different information to create a change set."),
+				Status:          aws.String(cloudformation.ChangeSetStatusFailed),
+				StatusReason:    aws.String("The submitted information didn't contain changes. Submit different information to create a change set."),
+				ExecutionStatus: aws.String(cloudformation.ExecutionStatusUnavailable),
 			},
 			nil,
 		).
@@ -260,8 +261,9 @@ func Test_Stage_Happy_NoopChangeSet_UploadArtefacts(t *testing.T) {
 		).
 		Return(
 			&cloudformation.DescribeChangeSetOutput{
-				Status:       aws.String(cloudformation.ChangeSetStatusFailed),
-				StatusReason: aws.String("The submitted information didn't contain changes. Submit different information to create a change set."),
+				Status:          aws.String(cloudformation.ChangeSetStatusFailed),
+				StatusReason:    aws.String("The submitted information didn't contain changes. Submit different information to create a change set."),
+				ExecutionStatus: aws.String(cloudformation.ExecutionStatusUnavailable),
 			},
 			nil,
 		).

--- a/internal/command/stage_happy_test.go
+++ b/internal/command/stage_happy_test.go
@@ -111,7 +111,7 @@ func Test_Stage_Happy_CreateChangeSet(t *testing.T) {
 
 	client := stratus.NewClient(cfn, nil)
 
-	_, err := command.Stage(context.Background(), client, stack)
+	_, _, err := command.Stage(context.Background(), client, stack)
 	assert.NoError(err)
 }
 
@@ -199,7 +199,7 @@ func Test_Stage_Happy_NoopChangeSet(t *testing.T) {
 
 	client := stratus.NewClient(cfn, nil)
 
-	_, err := command.Stage(context.Background(), client, stack)
+	_, _, err := command.Stage(context.Background(), client, stack)
 	assert.NoError(err)
 }
 
@@ -321,7 +321,7 @@ func Test_Stage_Happy_NoopChangeSet_UploadArtefacts(t *testing.T) {
 
 	client := stratus.NewClient(cfn, s3Client)
 
-	_, err := command.Stage(context.Background(), client, stack)
+	_, _, err := command.Stage(context.Background(), client, stack)
 	assert.NoError(err)
 }
 
@@ -403,6 +403,6 @@ func Test_Stage_Happy_UpdateChangeSet(t *testing.T) {
 
 	client := stratus.NewClient(cfn, nil)
 
-	_, err := command.Stage(context.Background(), client, stack)
+	_, _, err := command.Stage(context.Background(), client, stack)
 	assert.NoError(err)
 }

--- a/internal/stratus/client.go
+++ b/internal/stratus/client.go
@@ -222,7 +222,7 @@ func (client *Client) FindExistingChangeSet(
 ) (*cloudformation.DescribeChangeSetOutput, error) {
 	listOutput, err := client.listChangeSets(ctx, stack)
 	if isStackDoesNotExistError(err) {
-		return nil, fmt.Errorf("stack '%s' does not exist", stack.Name)
+		return nil, nil
 	}
 	if err != nil {
 		return nil, err
@@ -263,15 +263,11 @@ func (client *Client) FindExistingChangeSet(
 				)
 			}
 
-			if *summary.ExecutionStatus == cloudformation.ExecutionStatusUnavailable {
-				return nil, nil
-			}
-
 			return changeSetOutput, nil
 		}
 	}
 
-	return nil, fmt.Errorf("change set '*%s*' does not exist", stack.Checksum)
+	return nil, nil
 }
 
 func (client *Client) SetStackPolicy(
@@ -451,7 +447,7 @@ func (client *Client) handleCreateChangeSetError(
 		return err
 	}
 
-	if !isNoopChangeSet(describeOutput) {
+	if !IsNoopChangeSet(describeOutput) {
 		return err
 	}
 

--- a/internal/stratus/utils.go
+++ b/internal/stratus/utils.go
@@ -114,10 +114,12 @@ func isAcceptableChangeSetStatus(
 	return false
 }
 
-func isNoopChangeSet(output *cloudformation.DescribeChangeSetOutput) bool {
+func IsNoopChangeSet(output *cloudformation.DescribeChangeSetOutput) bool {
 	return output != nil &&
 		output.Status != nil &&
 		output.StatusReason != nil &&
+		output.ExecutionStatus != nil &&
+		*output.ExecutionStatus == cloudformation.ExecutionStatusUnavailable &&
 		*output.Status == cloudformation.ChangeSetStatusFailed &&
 		*output.StatusReason == noopChangeSetStatusReason
 }


### PR DESCRIPTION
A pattern that is used with stratus may be to `stage` in branch builds, and `deploy` in default branch builds.

Upon disasters, like accidental stack deletions or failed changes, retrying a build on a default branch to re-create the infrastructure or roll back, without worrying about making a temporary branch and staging, would be a fast path to recovery. This PR allows this to happen if and only if stratus finds a `FORCE_DEPLOY` environment variable set to `true`. 

Is this worth documenting? The error message will tell you what to do in a pinch.