### PR TITLE
Update policy before stack update

### DIFF
--- a/internal/command/deploy.go
+++ b/internal/command/deploy.go
@@ -7,6 +7,7 @@ import (
 	"github.com/72636c/stratus/internal/config"
 	"github.com/72636c/stratus/internal/context"
 	"github.com/72636c/stratus/internal/stratus"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
 )
 
 func Deploy(
@@ -37,11 +38,21 @@ func Deploy(
 		return fmt.Errorf("could not find existing change set")
 	}
 
-	logger.Title("Set stack policy")
+	logger.Title("Getting stack status")
 
-	err = client.SetStackPolicy(ctx, stack)
+	stackStatus, err := client.GetStackStatus(ctx, stack)
 	if err != nil {
 		return err
+	}
+
+	// Stack policies cannot be set on stacks that haven't finished creating
+	if stackStatus != cloudformation.StackStatusReviewInProgress {
+		logger.Title("Set stack policy")
+
+		err = client.SetStackPolicy(ctx, stack)
+		if err != nil {
+			return err
+		}
 	}
 
 	if stratus.IsNoopChangeSet(changeSet) {
@@ -50,6 +61,16 @@ func Deploy(
 		logger.Title("Execute change set")
 
 		err = client.ExecuteChangeSet(ctx, stack, *changeSet.ChangeSetName)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Apply earlier skipped stack policy
+	if stackStatus == cloudformation.StackStatusReviewInProgress {
+		logger.Title("Set stack policy")
+
+		err = client.SetStackPolicy(ctx, stack)
 		if err != nil {
 			return err
 		}

--- a/internal/command/deploy.go
+++ b/internal/command/deploy.go
@@ -37,6 +37,13 @@ func Deploy(
 		return fmt.Errorf("could not find existing change set")
 	}
 
+	logger.Title("Set stack policy")
+
+	err = client.SetStackPolicy(ctx, stack)
+	if err != nil {
+		return err
+	}
+
 	if stratus.IsNoopChangeSet(changeSet) {
 		logger.Title("No changes to execute.")
 	} else {
@@ -56,13 +63,6 @@ func Deploy(
 	}
 
 	logger.Data(outputs)
-
-	logger.Title("Set stack policy")
-
-	err = client.SetStackPolicy(ctx, stack)
-	if err != nil {
-		return err
-	}
 
 	logger.Title("Update termination protection")
 

--- a/internal/command/deploy_test.go
+++ b/internal/command/deploy_test.go
@@ -140,7 +140,8 @@ func Test_Deploy_Happy_ExistingChangeSet_Create(t *testing.T) {
 			&cloudformation.DescribeStacksOutput{
 				Stacks: []*cloudformation.Stack{
 					&cloudformation.Stack{
-						Outputs: make([]*cloudformation.Output, 0),
+						StackStatus: aws.String(cloudformation.StackStatusReviewInProgress),
+						Outputs:     make([]*cloudformation.Output, 0),
 					},
 				},
 			},
@@ -271,7 +272,8 @@ func Test_Deploy_Happy_ExistingChangeSet_Update(t *testing.T) {
 			&cloudformation.DescribeStacksOutput{
 				Stacks: []*cloudformation.Stack{
 					&cloudformation.Stack{
-						Outputs: make([]*cloudformation.Output, 0),
+						StackStatus: aws.String(cloudformation.StackStatusUpdateComplete),
+						Outputs:     make([]*cloudformation.Output, 0),
 					},
 				},
 			},
@@ -380,7 +382,8 @@ func Test_Deploy_Happy_NoopChangeSet(t *testing.T) {
 			&cloudformation.DescribeStacksOutput{
 				Stacks: []*cloudformation.Stack{
 					&cloudformation.Stack{
-						Outputs: make([]*cloudformation.Output, 0),
+						StackStatus: aws.String(cloudformation.StackStatusCreateComplete),
+						Outputs:     make([]*cloudformation.Output, 0),
 					},
 				},
 			},
@@ -492,7 +495,8 @@ func Test_Deploy_Happy_NoopChangeSet_UploadArtefacts(t *testing.T) {
 			&cloudformation.DescribeStacksOutput{
 				Stacks: []*cloudformation.Stack{
 					&cloudformation.Stack{
-						Outputs: make([]*cloudformation.Output, 0),
+						StackStatus: aws.String(cloudformation.StackStatusCreateComplete),
+						Outputs:     make([]*cloudformation.Output, 0),
 					},
 				},
 			},
@@ -608,6 +612,7 @@ func Test_Deploy_Happy_ImplicitStage(t *testing.T) {
 			&cloudformation.DescribeStacksOutput{
 				Stacks: []*cloudformation.Stack{
 					{
+						StackStatus:                 aws.String(cloudformation.StackStatusCreateComplete),
 						EnableTerminationProtection: aws.Bool(false),
 					},
 				},

--- a/internal/stratus/client.go
+++ b/internal/stratus/client.go
@@ -372,6 +372,18 @@ func (client *Client) ValidateTemplate(
 	return client.cfn.ValidateTemplateWithContext(ctx, input)
 }
 
+func (client *Client) GetStackStatus(
+	ctx context.Context,
+	stack *config.Stack,
+) (string, error) {
+	output, err := client.describeStack(ctx, stack)
+	if err != nil {
+		return "", err
+	}
+
+	return *output.StackStatus, nil
+}
+
 func (client *Client) describeChangeSet(
 	ctx context.Context,
 	stack *config.Stack,


### PR DESCRIPTION
This means that if you change a policy file, you can perform the update against it immediately.

Is there a reason this isn't a good idea? 🙏 